### PR TITLE
Add unauthorized response configuration property

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ The middleware will:
 
 JWT handling `config`:
 
-| Option                         | Description                                                                                                                                                                                                                                                |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `jwksUri`                      | The endpoint to load signing keys via [jwks-rsa](https://github.com/auth0/node-jwks-rsa#readme)                                                                                                                                                            |
-| `verifyOptions`                | The options passed into [jwt.verify](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)                                                                                                                         |
-| `explicitNoIssuerValidation`   | Optional. The default behaviour is to enforce issuer validation through `verifyOptions.issuer` to avoid security issues through misconfiguration.<br>If it's intentional to not validate the issuer of incoming tokens, set this property to `true`.       |
-| `explicitNoAudienceValidation` | Optional. The default behaviour is to enforce audience validation through `verifyOptions.audience` to avoid security issues through misconfiguration.<br>If it's intentional to not validate the audience of incoming tokens, set this property to `true`. |
+| Option                         | Description                                                                                                                                                                                                                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `jwksUri`                      | The endpoint to load signing keys via [jwks-rsa](https://github.com/auth0/node-jwks-rsa#readme)                                                                                                                                                                                |
+| `verifyOptions`                | The options passed into [jwt.verify](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)                                                                                                                                             |
+| `errorResponse`                | Optional. Delegate of type `(req: Request, res: Response) => Response)` which provides a way to customise the HTTP response when the token is required and not present, or the token validation fails.<br>If not provided, a plain text 401 Unauthorized response is returned. |
+| `explicitNoIssuerValidation`   | Optional. The default behaviour is to enforce issuer validation through `verifyOptions.issuer` to avoid security issues through misconfiguration.<br>If it's intentional to not validate the issuer of incoming tokens, set this property to `true`.                           |
+| `explicitNoAudienceValidation` | Optional. The default behaviour is to enforce audience validation through `verifyOptions.audience` to avoid security issues through misconfiguration.<br>If it's intentional to not validate the audience of incoming tokens, set this property to `true`.                     |
 
 ### Multitenant apps
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ app.post('/api/admin/*', (req, res, next) => {
 
 The middleware will:
 
-- Return `401 Unauthorised` when the JWT fails decoding / verification
-- Return `401 Unauthorised` if there is no `Bearer {token}` authorization header and `tokenIsRequired` is set to `true` (default is `false`)
+- Return `401 Unauthorized` when the JWT fails decoding / verification
+- Return `401 Unauthorized` if there is no `Bearer {token}` authorization header and `tokenIsRequired` is set to `true` (default is `false`)
 
 ## Options
 
@@ -54,13 +54,13 @@ The middleware will:
 
 JWT handling `config`:
 
-| Option                         | Description                                                                                                                                                                                                                                                                    |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `jwksUri`                      | The endpoint to load signing keys via [jwks-rsa](https://github.com/auth0/node-jwks-rsa#readme)                                                                                                                                                                                |
-| `verifyOptions`                | The options passed into [jwt.verify](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)                                                                                                                                             |
-| `errorResponse`                | Optional. Delegate of type `(req: Request, res: Response) => Response)` which provides a way to customise the HTTP response when the token is required and not present, or the token validation fails.<br>If not provided, a plain text 401 Unauthorized response is returned. |
-| `explicitNoIssuerValidation`   | Optional. The default behaviour is to enforce issuer validation through `verifyOptions.issuer` to avoid security issues through misconfiguration.<br>If it's intentional to not validate the issuer of incoming tokens, set this property to `true`.                           |
-| `explicitNoAudienceValidation` | Optional. The default behaviour is to enforce audience validation through `verifyOptions.audience` to avoid security issues through misconfiguration.<br>If it's intentional to not validate the audience of incoming tokens, set this property to `true`.                     |
+| Option                         | Description                                                                                                                                                                                                                                                                     |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `jwksUri`                      | The endpoint to load signing keys via [jwks-rsa](https://github.com/auth0/node-jwks-rsa#readme)                                                                                                                                                                                 |
+| `verifyOptions`                | The options passed into [jwt.verify](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback)                                                                                                                                              |
+| `unauthorizedResponse`         | Optional. Callback of type `(req: Request, res: Response) => Response)` which provides a way to customise the HTTP response when the bearer token is required and not present, or the validation fails.<br>If not provided, a plain text 401 Unauthorized response is returned. |
+| `explicitNoIssuerValidation`   | Optional. The default behaviour is to enforce issuer validation through `verifyOptions.issuer` to avoid security issues through misconfiguration.<br>If it's intentional to not validate the issuer of incoming tokens, set this property to `true`.                            |
+| `explicitNoAudienceValidation` | Optional. The default behaviour is to enforce audience validation through `verifyOptions.audience` to avoid security issues through misconfiguration.<br>If it's intentional to not validate the audience of incoming tokens, set this property to `true`.                      |
 
 ### Multitenant apps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/express-bearer",
-  "version": "0.3.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/express-bearer",
-      "version": "0.3.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@makerx/node-common": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/express-bearer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": false,
   "description": "",
   "author": "MakerX",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '@makerx/node-common'
-import type { RequestHandler, Response } from 'express'
+import type { Request, RequestHandler, Response } from 'express'
 import { GetPublicKeyOrSecret, JwtPayload, verify, VerifyOptions } from 'jsonwebtoken'
 import { JwksClient } from 'jwks-rsa'
 
@@ -24,6 +24,16 @@ export interface BearerConfig {
   verifyOptions: VerifyOptions
 
   /**
+   * Callback invoked when an error happens:
+   *
+   *  - The token is required and is not present, or
+   *  - The token validation fails.
+   *
+   *  When not provided, a plain text 401 Unauthorized response is returned.
+   */
+  errorResponse?: (req: Request, res: Response) => Response
+
+  /**
    * The default behaviour is to require that verifyOptions.issuer is set, for security purposes.
    * If the intended behaviour is to not validate the issuer, set this property to true.
    */
@@ -44,17 +54,26 @@ export interface BearerAuthOptions {
   logger?: Logger
 }
 
+const resolveConfig = (config: BearerConfig | BearerConfigCallback, host: string): BearerConfig => {
+  if (typeof config === 'function') return config(host)
+  return config
+}
+
 const cacheByHost: Record<string, { verifyOptions: VerifyOptions; jwksClient: JwksClient; getKey: GetPublicKeyOrSecret }> = {}
 export const verifyForHost = (host: string, jwt: string, config: BearerConfig | BearerConfigCallback): Promise<JwtPayload> => {
   if (!cacheByHost[host]) {
-    const { jwksUri, verifyOptions, explicitNoIssuerValidation, explicitNoAudienceValidation } = typeof config === 'function' ? config(host) : config
+    const { jwksUri, verifyOptions, explicitNoIssuerValidation, explicitNoAudienceValidation } = resolveConfig(config, host)
 
     if (!explicitNoIssuerValidation && !verifyOptions.issuer) {
-      throw new Error('You need to set verifyOptions.issuer, or set explicitNoIssuerValidation to true if you explicitly want to skip issuer validation')
+      throw new Error(
+        'You need to set verifyOptions.issuer, or set explicitNoIssuerValidation to true if you explicitly want to skip issuer validation'
+      )
     }
 
     if (!explicitNoAudienceValidation && !verifyOptions.audience) {
-      throw new Error('You need to set verifyOptions.audience, or set explicitNoAudienceValidation to true if you explicitly want to skip audience validation')
+      throw new Error(
+        'You need to set verifyOptions.audience, or set explicitNoAudienceValidation to true if you explicitly want to skip audience validation'
+      )
     }
 
     const jwksClient = new JwksClient({ jwksUri })
@@ -82,24 +101,28 @@ export const verifyForHost = (host: string, jwt: string, config: BearerConfig | 
   })
 }
 
+const defaultErrorResponse = (_req: Request, res: Response) => res.status(401).send('Unauthorized').end()
 export const bearerTokenMiddleware = ({ config, tokenIsRequired, logger }: BearerAuthOptions): RequestHandler => {
-  const unauthorized = (res: Response) => res.status(401).send('Unauthorized').end()
   const handler: RequestHandler = (req, res, next) => {
+    const host = req.headers.host ?? ''
+    const resolvedConfig = resolveConfig(config, host)
+    const errorResponse = resolvedConfig.errorResponse ?? defaultErrorResponse
+
     if (!req.headers.authorization?.startsWith('Bearer ')) {
       if (!tokenIsRequired) return next()
       logger?.debug('Bearer token not supplied')
-      return unauthorized(res)
+      return errorResponse(req, res)
     }
 
     const jwt = req.headers.authorization?.substring(7)
-    verifyForHost(req.headers.host ?? '', jwt, config)
+    verifyForHost(host, jwt, config)
       .then((claims) => {
         req.user = claims
         next()
       })
       .catch((error: unknown) => {
         logger?.error('Bearer token verification failed', { host: req.headers.host, error })
-        unauthorized(res)
+        errorResponse(req, res)
       })
   }
 


### PR DESCRIPTION
Fixes #11.

I tried it locally and it worked as expected.

I didn't know Apollo Sandbox was expecting JSON responses to be in a specific format, I initially made a mistake and returned the below, and it wouldn't show in the UI:

```json
{
  "errors": {
    "message": "Unauthorized"
  }
}
```

The `errors` property needs to be an array of objects, each containing a `message` property.

Another thing worth noting is, with the way we do things, the typed configuration needs to be spread out so we can configure the `errorResponse` in code, from:

```typescript
app.use(
  bearerTokenMiddleware({
    config: config.get('auth.bearer'),
    tokenIsRequired: false,
    logger,
  }),
)
```

to

```typescript
app.use(
  bearerTokenMiddleware({
    config: {
      ...config.get('auth.bearer'),
      unauthorizedResponse: (_, res) => res.status(401).json({ errors: [{ message: 'Unauthorized' }] }).end(),
    },
    tokenIsRequired: false,
    logger,
  }),
)
```