### PR TITLE
Fix output directory of the `index.d.ts` file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/express-bearer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/express-bearer",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/eslintrc": "3.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "node": ">=16.0"
       },
       "peerDependencies": {
-        "express": "*",
+        "express": ">=4",
         "jsonwebtoken": ">=9",
         "jwks-rsa": ">=3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/express-bearer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": false,
   "description": "Bearer token validation middleware for Express.js",
   "author": "MakerX",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src/",
     "outDir": "./dist/",
     "noEmit": false,
     "declaration": true


### PR DESCRIPTION
Follow-up to #18.

## What

This fixes the location of the `index.d.ts` file which was under the `src` directory after the update to TypeScript 6.

## Why

- <https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#rootdir-now-defaults-to->.
- <https://gist.github.com/privatenumber/3d2e80da28f84ee30b77d53e1693378f#15-rootdir-defaults-to--directory-of-tsconfigjson>.